### PR TITLE
Less strict from_hash method

### DIFF
--- a/lib/algebrick.rb
+++ b/lib/algebrick.rb
@@ -270,8 +270,8 @@ module Algebrick
     end
   end
 
-  TYPE_KEY   = :algebrick
-  FIELDS_KEY = :fields
+  TYPE_KEY   = :algebrick_type
+  FIELDS_KEY = :algebrick_fields
 
   # Representation of Atomic types
   class Atom < Type

--- a/spec/algebrick_test.rb
+++ b/spec/algebrick_test.rb
@@ -177,9 +177,9 @@ describe 'AlgebrickTest' do
     it { Named.from_hash(Named[1, :a].to_hash).must_equal Named[1, :a] }
     it do
       Named[1, Node[Leaf[1], Empty]].to_hash.
-          must_equal algebrick: 'Named', a: 1, b: { algebrick: 'Node',
-                                                    fields:    [{ algebrick: 'Leaf', fields: [1] },
-                                                                { algebrick: 'Empty' }] }
+          must_equal algebrick_type: 'Named', a: 1, b: { algebrick_type: 'Node',
+                                                         algebrick_fields:    [{ algebrick_type: 'Leaf', algebrick_fields: [1] },
+                                                                               { algebrick_type: 'Empty' }] }
     end
     it do
       Named.from_hash(Named[1, Node[Leaf[1], Empty]].to_hash).
@@ -703,7 +703,7 @@ Named[
 
     it "doesn't give up when the algebrick key doesn't tell true" do
       person = Person.from_hash(name: 'Peter Parker',
-                                address: { algebrick: "Person::RenamedAddress",
+                                address: { algebrick_type: "Person::RenamedAddress",
                                            street: "One two three",
                                            city:   "Springfield",
                                            zip:     60200 })
@@ -720,7 +720,7 @@ Named[
 
     it "tries the type suggested in algebrick key, but falls back to the expected type when needed" do
       person = Person.from_hash(name: 'Peter Parker',
-                                address: { algebrick: "Address",
+                                address: { algebrick_type: "Address",
                                            street: "One two three",
                                            city:   "Springfield",
                                            zip:     60200 })


### PR DESCRIPTION
There is no reason why the type couldn't accept hash that contains
the data it needs. Therefore, I've made the TYPE_KEY optional and
not the only source of truth. When deserializing, we can take advantage
of knowing what type is expected. Sometimes it's not known, therefore
we need the hint of TYPE_KEY, but for most cases it works.

This allows to take any hash and load it as algbrick type directly,
useful for desribing any hashes, especially from REST or message queue.
I could imaging this being used in Dynflow as well.
