### PR TITLE
implement Object#hash and Object#eql?

### DIFF
--- a/lib/algebrick/product_constructors/abstract.rb
+++ b/lib/algebrick/product_constructors/abstract.rb
@@ -39,6 +39,12 @@ module Algebrick
         @fields == other.fields
       end
 
+      alias_method :eql?, :==
+
+      def hash
+        [self.class, @fields].hash
+      end
+
       def self.type
         @type || raise
       end

--- a/test/algebrick_test.rb
+++ b/test/algebrick_test.rb
@@ -108,6 +108,9 @@ describe 'AlgebrickTest' do
     it { assert Empty === Empty }
     it { eval(Empty.to_s).must_equal Empty }
     it { eval(Empty.inspect).must_equal Empty }
+
+    it { assert Empty.hash == Empty.hash }
+    it { assert Empty.eql?(Empty) }
   end
 
   describe 'product' do
@@ -124,6 +127,8 @@ describe 'AlgebrickTest' do
     it { eval(Leaf[1].inspect).must_equal Leaf[1] }
     it { eval(Node[Leaf[1], Empty].to_s).must_equal Node[Leaf[1], Empty] }
     it { eval(Node[Leaf[1], Empty].inspect).must_equal Node[Leaf[1], Empty] }
+    it { assert Leaf[1].hash == Leaf[1].hash }
+    it { assert Leaf[1].eql?(Leaf[1]) }
 
     it 'field assign' do
       value = Leaf[1].value
@@ -225,6 +230,8 @@ describe 'AlgebrickTest' do
     it { assert List === List[1, Empty] }
     it { assert List === Empty }
     it { assert List[1, Empty].kind_of? List }
+    it { assert List[1, Empty].hash == List[1, Empty].hash }
+    it { assert List[1, Empty].eql?(List[1, Empty]) }
   end
 
   describe 'inspecting' do
@@ -612,6 +619,8 @@ Named[
       it "equals #{tree1}" do
         refute tree1.object_id == tree2.object_id, [tree1.object_id, tree2.object_id] unless tree1 == Empty
         assert tree1 == tree2
+        assert tree1.hash == tree2.hash
+        assert tree1.eql?(tree2)
       end
     end
   end


### PR DESCRIPTION
add methods so that Algebrick values can be used as hash keys and/or as set members (including from Hamster::Hash and Hamster::Set)

I was playing around with Algebrick and noticed errors when trying to use it with [`Hamster::Set`](http://www.rubydoc.info/github/hamstergem/hamster/master/Hamster/Set). Specifically, adding a value to a set, and then checking to see if another value that was equal, but a different object instance was in the set with `Hamster::Set#include?`, it would return false.

Digging into it, `Hamster::Set` implements the same semantics as plain Ruby Sets, and expects `Object#hash` and `Object#eql?` to be implemented on values for it to be able to see them as being included already.

Currently Algebrick doesn't do this, and relies on the default Object methods (which work on object identity, rather than value equality).

This pull request fixes that.

Not sure if this is maintained or not anymore, but it's an interesting project to play around with :)