### PR TITLE
fix: Failed to match a class with mimic name

### DIFF
--- a/lib/algebrick/type_check.rb
+++ b/lib/algebrick/type_check.rb
@@ -18,7 +18,9 @@ module Algebrick
     # FIND: type checking of collections?
 
     def Type?(value, *types)
-      types.any? { |t| value.is_a? t }
+      types.any? do |t|
+        value.is_a?(t) || value.class.name.objectize.ancestors.include?(t)
+      end
     end
 
     def Type!(value, *types)
@@ -53,6 +55,15 @@ module Algebrick
     def self.error(value, message, types)
       raise TypeError,
             "Value (#{value.class}) '#{value}' #{message} any of: #{types.join('; ')}."
+    end
+  end
+
+  class ::String
+    def objectize
+      self.split("::").reduce(Object) do |o, token|
+        /(.*)\(.*\)/ =~ token
+        o.const_get($1 || token)
+      end
     end
   end
 end

--- a/test/algebrick_test.rb
+++ b/test/algebrick_test.rb
@@ -31,6 +31,23 @@ describe 'AlgebrickTest' do
       variants Empty, Leaf
     end
 
+    ATime = type do |_|
+      variants ::Time, ::NilClass
+    end
+
+    class ::FakeTime
+       class << self
+          def name
+             "Time"
+          end
+       end
+
+       def is_a?(klass)
+         klass == ::Time || super
+       end
+       alias_method :kind_of?, :is_a?
+    end
+
     Tree.set_variants Node
 
     BTree = type do |btree|
@@ -214,6 +231,17 @@ describe 'AlgebrickTest' do
     describe 'a klass as a variant' do
       MaybeString = Algebrick.type { variants Empty, String }
       it { 'a'.must_be_kind_of MaybeString }
+    end
+  end
+
+  describe 'variant for fake class' do
+    it { ATime.must_be_kind_of Algebrick::ProductVariant }
+    it { assert ATime.variants === [Time, NilClass] }
+    it { assert FakeTime.name === "Time" }
+    it { FakeTime.new.is_a?(Time) }
+    it do
+      extend Algebrick::TypeCheck
+      assert Type?(FakeTime.new, ATime) === true
     end
   end
 


### PR DESCRIPTION
- [x] ! fixed fake class matching when it uses changed or mimic name

This is fix to problem which is risen when a class which mimiced to an other one isn't matched to the class which is included into product variant match list. For example TimeWithZone from rails is mimiced to Time class, and even if Time is a variant of the algebrick type, the variable of type TimeWithZone isn't matched to that algebrick type.
```log
2021-02-02T23:40:35 [E|bac|] Value (ActiveSupport::TimeWithZone) '2021-02-02 23:40:50 +0300' is not any of: (Time | NilClass). (TypeError)
/usr/lib/ruby/gems/2.7.0/gems/algebrick-0.7.5/lib/algebrick/type_check.rb:54:in `error'
/usr/lib/ruby/gems/2.7.0/gems/algebrick-0.7.5/lib/algebrick/type_check.rb:26:in `Type!'
/usr/lib/ruby/gems/2.7.0/gems/algebrick-0.7.5/lib/algebrick/product_constructors/abstract.rb:39:in `block in initialize'
/usr/lib/ruby/gems/2.7.0/gems/algebrick-0.7.5/lib/algebrick/product_constructors/abstract.rb:39:in `map'
/usr/lib/ruby/gems/2.7.0/gems/algebrick-0.7.5/lib/algebrick/product_constructors/abstract.rb:39:in `initialize'
/usr/lib/ruby/gems/2.7.0/gems/algebrick-0.7.5/lib/algebrick/product_variant.rb:90:in `new'
/usr/lib/ruby/gems/2.7.0/gems/dynflow-1.4.7/lib/dynflow/world.rb:227:in `plan_event'
/usr/lib/ruby/gems/2.7.0/gems/dynflow-1.4.7/lib/dynflow/action/suspended.rb:13:in `plan_event'
/usr/lib/ruby/gems/2.7.0/gems/dynflow-1.4.7/lib/dynflow/clock.rb:121:in `ping'
<...>
```